### PR TITLE
Style Adjustments to Select

### DIFF
--- a/resources/views/core/select.blade.php
+++ b/resources/views/core/select.blade.php
@@ -179,7 +179,7 @@ event fires.
     >
     <button type="button" id="{{ $id }}-toggle" aria-labeledBy={{ $labeledBy? $labeledBy: $id . '-label'}} x-ref="selectButton" @click="selectOpen=!selectOpen"
         :class="{ 'focus:ring-2 focus:ring-offset-2 focus:ring-accent hover:bg-base-200' : !selectOpen }"
-        {{ $attributes->twMergeFor('button', 'relative min-h-[38px] flex items-center justify-between w-full py-2 pl-3 pr-10 text-left bg-base-100 border rounded-md shadow-sm cursor-default border-base-300 focus:outline-none cursor-pointer' )}}
+        {{ $attributes->twMergeFor('button', 'relative min-h-[28px] flex items-center justify-between w-full py-0.25 pl-2 pr-10 text-left bg-base-100 border rounded-md shadow-sm cursor-default border-base-300 focus:outline-none cursor-pointer' )}}
         >
 
         <span x-text="selectedItem ? selectedItem.title : '{{ $select_text }}'" class="truncate">{{ $select_text }}</span>
@@ -196,7 +196,7 @@ event fires.
         x-transition:enter-start="opacity-0 -translate-y-1"
         x-transition:enter-end="opacity-100"
         :class="{ 'bottom-0 mb-11' : selectDropdownPosition == 'top', 'top-0 mt-11' : selectDropdownPosition == 'bottom' }"
-        class="absolute w-full py-1 z-10 mt-1 overflow-auto bg-white rounded-md shadow-md max-h-56 ring-1 ring-black ring-opacity-5 focus:outline-none"
+        class="absolute w-fit z-10 mt-1 overflow-auto bg-white rounded-md shadow-md max-h-56 ring-1 ring-black ring-opacity-5 focus:outline-none"
         x-cloak>
 
         <template x-for="(item, index) in selectableItems" :key="index + '-' + item.value">
@@ -206,7 +206,7 @@ event fires.
                 :data-disabled="item.disabled"
                 :class="{ 'bg-base-200 text-base-content' : selectableItemIsActive(item), '' : !selectableItemIsActive(item) }"
                 @mousemove="selectableItemActive=item"
-                class="relative flex items-center h-full py-2 pl-8 text-base-content cursor-default select-none data-[disabled]:opacity-50 data-[disabled]:pointer-events-none">
+                class="relative flex items-center h-full py-2 px-8 text-base-content cursor-default select-none data-[disabled]:opacity-50 data-[disabled]:pointer-events-none">
                 <svg x-show="selectedItem.value==item.value" class="absolute left-0 w-4 h-4 ml-2 stroke-current text-base-content/50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
                 <span class="block font-medium truncate" x-text="item.title"></span>
             </li>


### PR DESCRIPTION
# Summary
No issue just small visual change.

Makes height the same as the input element so they can be inline when using flex rows.
Changed the menu so that it fits the contents and doesn't use the container width cutting off label's


## Before
<img width="1357" height="62" alt="before_select" src="https://github.com/user-attachments/assets/0df81f19-4f7d-45ca-8799-697241844c3f" />

<img width="187" height="203" alt="before_select_menu" src="https://github.com/user-attachments/assets/44e95ae9-99fc-4a51-9557-2ca3ef0cdc6a" />

## After
<img width="263" height="200" alt="after_select_menu" src="https://github.com/user-attachments/assets/4e4a33a9-871d-4607-bc5c-f47548a38ae7" />

<img width="1357" height="57" alt="after_select" src="https://github.com/user-attachments/assets/3cf59ea8-9c67-4f22-9f1f-e9b458c10e6c" />

