### PR TITLE
Component lib link css

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -29,6 +29,10 @@
 @layer components {
     /* Custom CSS for Single HTML Tag components goes here */
 
+    .x-link {
+        @apply text-link-darker hover:text-link-lighter inline w-fit font-medium underline hover:brightness-100;
+    }
+
     /* Style Markdown components */
     .markdown {
         h1,

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -29,7 +29,7 @@
 @layer components {
     /* Custom CSS for Single HTML Tag components goes here */
 
-    .x-link {
+    .x-link, .markdown a {
         @apply text-link-darker hover:text-link-lighter inline w-fit font-medium underline hover:brightness-100;
     }
 
@@ -76,14 +76,6 @@
             color: theme("colors.base.content");
             border-radius: theme("borderRadius.full");
             padding: 0 theme("padding.2");
-        }
-
-        a {
-            color: theme("colors.link.DEFAULT");
-
-            &:hover {
-                color: theme("colors.link.lighter");
-            }
         }
 
         ul ul {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -29,7 +29,8 @@
 @layer components {
     /* Custom CSS for Single HTML Tag components goes here */
 
-    .x-link, .markdown a {
+    .x-link,
+    .markdown a {
         @apply text-link-darker hover:text-link-lighter inline w-fit font-medium underline hover:brightness-100;
     }
 

--- a/resources/views/core/link.blade.php
+++ b/resources/views/core/link.blade.php
@@ -1,10 +1,1 @@
-<a
-    {{
-$attributes->twMerge('
-underline inline w-fit
-font-medium text-link-darker
-hover:text-link-lighter hover:brightness-100
-')
-}}
-    >{{ $slot }}</a
->
+<a {{ $attributes->twMerge('x-link') }}>{{ $slot }}</a>


### PR DESCRIPTION
# Summary
Pull tailwind classes for links as css class. Mostly to save on html size when a lot of links are used. Example is the sitemap page.

Probably should have just started out doing it this way for simple components. Added benefit is the linking of styles between the markdown class and component so links from user generated content match the styles of the site.

Only css changes.