### PR TITLE
Enhancement better form labels

### DIFF
--- a/resources/views/core/form-label.blade.php
+++ b/resources/views/core/form-label.blade.php
@@ -1,0 +1,16 @@
+@props(['label', 'for' => null, 'id' => null, 'required' => false, 'inline' => false ])
+
+<label
+    id="{{ $id }}"
+    for="{{ $for }}"
+    @class(['text-base-content text-base font-bold', 'mb-1' => !$inline, 'flex items-center' => $inline])
+>
+    {{ $label }}
+    @if($required)
+        <span class="vertical-align text-error pr-1 italic">*</span>
+    @endif
+    @if($inline)
+        <span>:</span>
+    @endif
+</label>
+<span data-label="{{ $label }}"></span>

--- a/resources/views/core/input.blade.php
+++ b/resources/views/core/input.blade.php
@@ -1,4 +1,4 @@
-@props(['id'=> uniqid(), 'name' => $id, 'label' => false, 'error_text', 'assistive_text', 'area' => false, 'inline' => false, 'x-show'])
+@props(['id'=> uniqid(), 'name' => $id ?? null, 'label' => false, 'error_text', 'assistive_text', 'area' => false, 'inline' => false, 'x-show'])
 
 <!-- resources/views/core/input.blade.php -->
 <div

--- a/resources/views/core/input.blade.php
+++ b/resources/views/core/input.blade.php
@@ -1,4 +1,4 @@
-@props(['id'=> uniqid(), 'name', 'label' => false, 'error_text', 'assistive_text', 'area' => false, 'inline' => false, 'x-show'])
+@props(['id'=> uniqid(), 'name' => $id, 'label' => false, 'error_text', 'assistive_text', 'area' => false, 'inline' => false, 'x-show'])
 
 <!-- resources/views/core/input.blade.php -->
 <div
@@ -10,34 +10,25 @@
     @isset(${'x-show'}) x-show="{{ ${'x-show'} }}"@endisset
 >
     @if($label)
-        <label @class(['text-base-content text-base font-bold', 'mb-1' => !$inline, 'flex items-center' => $inline])>
-            {{ $label }}
-            @if($attributes['aria-required'] || $attributes['required'])
-                <span class="vertical-align text-error pr-1 italic">*</span>
-            @endif
-            @if($inline)
-                <span>:</span>
-            @endif
-        </label>
-        <span data-label="{{ $label }}"></span>
+        <x-form-label
+            :label="$label"
+            :for="$id"
+            :required="$attributes['aria-required'] || $attributes['required']"
+            :inline="$inline"
+        />
     @endif
 
+    @php
+        $inputStyles = [
+            'px-1 py-0.25 border-base-300 border rounded-md focus:ring-accent focus:ring-2 focus:outline-none',
+            $inline? 'grow': 'w-full'
+        ];
+    @endphp
+
     @if($area)
-        <textarea
-            name="{{ $name?? $id }}"
-            id="{{ $id }}"
-            {{ $attributes->twMerge('px-1 py-0.25 border-base-300 border rounded-md focus:ring-accent focus:ring-2 focus:outline-none w-full') }}
-            >{{ $slot }}</textarea
-        >
+        <textarea name="{{ $name }}" id="{{ $id }}" {{ $attributes->twMerge($inputStyles) }}>{{ $slot }}</textarea>
     @else
-        <input
-            {{
-$attributes->twMerge('px-1 py-0.25 border-base-300 border rounded-md focus:ring-accent focus:ring-2 focus:outline-none w-full
-        ')
-}}
-            name="{{ $name ?? $id }}"
-            id="{{ $id }}"
-        />
+        <input {{ $attributes->twMerge($inputStyles) }} name="{{ $name }}" id="{{ $id }}" />
     @endif
 
     @if(isset($error_text))

--- a/resources/views/core/pages/media/search.blade.php
+++ b/resources/views/core/pages/media/search.blade.php
@@ -37,7 +37,7 @@
             />
 
             <div>
-                <label id="media-tag-label" class="text-lg">Multimedia Tags</label>
+                <x-form-label label="Multimedia Tags" id="media-tag-label" />
                 <div class="flex gap-1">
                     <x-select
                         labeledBy="media-tag-label"

--- a/resources/views/core/radio.blade.php
+++ b/resources/views/core/radio.blade.php
@@ -1,6 +1,11 @@
 @props(['options'=> [], 'default_value' => null, 'name', 'label' => '', 'required' => false])
 <fieldset class="flex flex-row gap-2">
-    <legend class="text text-bold">{{ $label }}</legend>
+    <legend class="text-base-content text-base font-bold">
+        {{ $label }}
+        @if($required)
+            <span class="vertical-align text-error pr-1 italic">*</span>
+        @endif
+    </legend>
 
     @foreach($options as $option)
         <x-radio.item

--- a/resources/views/core/select.blade.php
+++ b/resources/views/core/select.blade.php
@@ -20,7 +20,8 @@ event fires.
     'id' => uniqid(),
     'bind_id' => false,
     'labeledBy' => null,
-    'select_text' => 'Select Item'
+    'select_text' => 'Select Item',
+    'inline' => false
 ])
 @php
     if($defaultValue !== null && !$default) {
@@ -34,12 +35,17 @@ event fires.
     }
 @endphp
 
-<div {{ $attributes->withoutTwMergeClasses()->twMerge("w-fit h-fit") }}>
+<div {{
+$attributes->withoutTwMergeClasses()->twMerge("w-fit h-fit",
+$inline? 'flex flex-wrap items-center gap-1': ''
+)
+}}>
     @if($label)
         <x-form-label
             :label="$label"
             :for="$id . '-toggle'"
             :id="$id . '-label'"
+            :inline="$inline"
             :required="$attributes['aria-required'] || $attributes['required']"
         />
     @endif

--- a/resources/views/core/select.blade.php
+++ b/resources/views/core/select.blade.php
@@ -35,8 +35,13 @@ event fires.
 @endphp
 
 <div {{ $attributes->withoutTwMergeClasses()->twMerge("w-fit h-fit") }}>
-    @if($label ?? false)
-        <label class="text" id="{{ $id }}-label" for="{{ $id }}-toggle">{{ $label }}</label>
+    @if($label)
+        <x-form-label
+            :label="$label"
+            :for="$id . '-toggle'"
+            :id="$id . '-label'"
+            :required="$attributes['aria-required'] || $attributes['required']"
+        />
     @endif
     <div
         x-data="{

--- a/resources/views/core/taxa-search.blade.php
+++ b/resources/views/core/taxa-search.blade.php
@@ -17,7 +17,7 @@ $taxa_type_id = 'taxa-type-' . $id;
 $includes = !$hide_synonyms_checkbox? ['#' . $use_thes_id]: [];
 @endphp
 <div>
-    <label class="text-lg" for="{{ $id }}">{{ $label }}</label>
+    <x-form-label :label="$label" :for="$id" :required="$attributes['aria-required'] || $attributes['required']" />
     <div class="group flex items-center">
         @if(!$hide_selector)
             @php $includes[] = '#' . $taxa_type_id @endphp


### PR DESCRIPTION
# Summary
- Adds form label component to re use (This could still use some work but it is better than before)
- Adds better inline support for the input component
- Adds inline support for select component
- Adds form label styles to radio
- Adds form label to select

Goal here is to make it easier to use form components while keeping styles aligned  

Example of inline
```blade
<x-input
    id="institutionCode"
    :label="__('misc_collmetadata.INST_CODE')"
    :inline="false"
    value="{{ $institutionCode }}"
    required
/>
```

<img width="1221" height="189" alt="screenshot" src="https://github.com/user-attachments/assets/361d663b-7f18-4ecf-9c24-484af1c2c8bb" />

# Pull Request Checklist During the Blitz Phase:

# Pre-Approval, Blitz Phase
- [x] There are no linter errors
- [x] Has Pint been run?
- [x] Have the required updates to the .env.example been made?

# Code Review, Blitz Phase
- [ ] QA not required, but go ahead and do if the situation requires it
- [ ] PR should be squash merged
- [ ] Code reviewer can go ahead and merge a PR after approving the code review
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.