### PR TITLE
Adds fallbacks if $_ENV is missing

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -62,7 +62,13 @@ $app = require_once __DIR__ . '/../bootstrap/app.php';
 (new IlluminateLoadEnvironmentVariables())->bootstrap($app);
 //(new LoadConfiguration)->bootstrap($app);
 
-$SYMBINI_PATH = __DIR__ . '/../' . $_ENV['PORTAL_NAME'] . '/config/symbini.php';
+$env = static function (string $key, $default = null) {
+    $value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+
+    return $value === false ? $default : $value;
+};
+
+$SYMBINI_PATH = __DIR__ . '/../' . $env('PORTAL_NAME', 'Portal') . '/config/symbini.php';
 
 if (file_exists($SYMBINI_PATH)) {
     include_once $SYMBINI_PATH;
@@ -115,9 +121,9 @@ $legacy_routes = [
 $legacy_black_list = [];
 foreach ($legacy_routes as $route => $redirect) {
     if (is_callable($redirect)) {
-        $legacy_black_list[$GLOBALS['CLIENT_ROOT'] . '/' . $route] = $_ENV['APP_URL'] . $redirect();
+        $legacy_black_list[$GLOBALS['CLIENT_ROOT'] . '/' . $route] = $env('APP_URL', '') . $redirect();
     } else {
-        $legacy_black_list[$GLOBALS['CLIENT_ROOT'] . '/' . $route] = $_ENV['APP_URL'] . $redirect;
+        $legacy_black_list[$GLOBALS['CLIENT_ROOT'] . '/' . $route] = $env('APP_URL', '') . $redirect;
     }
 }
 
@@ -133,7 +139,7 @@ $query = $query_pos ?
 
 /* Clean out host url if present */
 $https = (empty($_SERVER['HTTPS']) ? 'http://' : 'https://');
-$app_url = str_replace([$https, $_SERVER['HTTP_HOST']], '', $_ENV['APP_URL']);
+$app_url = str_replace([$https, $_SERVER['HTTP_HOST']], '', $env('APP_URL', ''));
 if ($app_url) {
     $uri = str_replace($app_url, '', $uri);
 }
@@ -240,13 +246,15 @@ if (isset($legacy_black_list[$uri]) && $blacklist_redirect = $legacy_black_list[
             // its facades behind within the kernal which will break the legacy application.
             class LegacyProfile extends ProfileManager {
                 public function authenticate($pwd = '') {
-                    $session_name = str_replace([' ', '-'], '_', strtolower($_ENV['APP_NAME'])) . '_session';
+                    global $env;
+
+                    $session_name = str_replace([' ', '-'], '_', strtolower($env('APP_NAME', 'laravel'))) . '_session';
                     $session = $_COOKIE[$session_name];
                     if (! $session) {
                         return;
                     }
 
-                    $key = base64_decode(Str::after($_ENV['APP_KEY'], 'base64:'));
+                    $key = base64_decode(Str::after((string) $env('APP_KEY', ''), 'base64:'));
 
                     if (! $key) {
                         error_log('No encryption key for legacy application');

--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Session\FileSessionHandler;
 use Illuminate\Session\Store;
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
@@ -62,13 +63,7 @@ $app = require_once __DIR__ . '/../bootstrap/app.php';
 (new IlluminateLoadEnvironmentVariables())->bootstrap($app);
 //(new LoadConfiguration)->bootstrap($app);
 
-$env = static function (string $key, $default = null) {
-    $value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
-
-    return $value === false ? $default : $value;
-};
-
-$SYMBINI_PATH = __DIR__ . '/../' . $env('PORTAL_NAME', 'Portal') . '/config/symbini.php';
+$SYMBINI_PATH = __DIR__ . '/../' . Env::get('PORTAL_NAME', 'Portal') . '/config/symbini.php';
 
 if (file_exists($SYMBINI_PATH)) {
     include_once $SYMBINI_PATH;
@@ -121,9 +116,9 @@ $legacy_routes = [
 $legacy_black_list = [];
 foreach ($legacy_routes as $route => $redirect) {
     if (is_callable($redirect)) {
-        $legacy_black_list[$GLOBALS['CLIENT_ROOT'] . '/' . $route] = $env('APP_URL', '') . $redirect();
+        $legacy_black_list[$GLOBALS['CLIENT_ROOT'] . '/' . $route] = Env::get('APP_URL', '') . $redirect();
     } else {
-        $legacy_black_list[$GLOBALS['CLIENT_ROOT'] . '/' . $route] = $env('APP_URL', '') . $redirect;
+        $legacy_black_list[$GLOBALS['CLIENT_ROOT'] . '/' . $route] = Env::get('APP_URL', '') . $redirect;
     }
 }
 
@@ -139,7 +134,7 @@ $query = $query_pos ?
 
 /* Clean out host url if present */
 $https = (empty($_SERVER['HTTPS']) ? 'http://' : 'https://');
-$app_url = str_replace([$https, $_SERVER['HTTP_HOST']], '', $env('APP_URL', ''));
+$app_url = str_replace([$https, $_SERVER['HTTP_HOST']], '', Env::get('APP_URL', ''));
 if ($app_url) {
     $uri = str_replace($app_url, '', $uri);
 }
@@ -246,15 +241,13 @@ if (isset($legacy_black_list[$uri]) && $blacklist_redirect = $legacy_black_list[
             // its facades behind within the kernal which will break the legacy application.
             class LegacyProfile extends ProfileManager {
                 public function authenticate($pwd = '') {
-                    global $env;
-
-                    $session_name = str_replace([' ', '-'], '_', strtolower($env('APP_NAME', 'laravel'))) . '_session';
+                    $session_name = str_replace([' ', '-'], '_', strtolower(Env::get('APP_NAME', 'laravel'))) . '_session';
                     $session = $_COOKIE[$session_name];
                     if (! $session) {
                         return;
                     }
 
-                    $key = base64_decode(Str::after((string) $env('APP_KEY', ''), 'base64:'));
+                    $key = base64_decode(Str::after((string) Env::get('APP_KEY', ''), 'base64:'));
 
                     if (! $key) {
                         error_log('No encryption key for legacy application');


### PR DESCRIPTION
# Description

Recent code in the `main` branch relies on `$_ENV['PORTAL_NAME']` in public/index.php. Apparently, not all PHP CLIs come with E(nvironment) preconfigured in their `variables_order`. Sometimes, it's in the `$_SERVER` instead, and sometimes not at all, requiring `getenv()` instead. This PR provides those fallbacks in the event that they are missing from the PHP CLI wherever Symbiota-Laravel is being installed.

My thinking was that having this fallback would be easier than adding this stipulation of making sure `variables_order` has `E` to the installation instructions. 

This is likely a moot point for containerized instances, but an easy enough fix to keep it working as expected for those of us not using the containerized version just yet, for whatever reason.

Specifcially, this is a cherry pick of commit 06bbe13 in the `taxonomy-editor-pt2` branch, just in its own branch in order to get it into the `main` branch faster.

# Pull Request Checklist During the Blitz Phase:

# Pre-Approval, Blitz Phase

- [ ] Comment which GitHub issue(s), if any does this PR address
- [x] If more description is required, add a description section
- [ ] Are (basic) tests written to cover the new functionality?
- [ ] If there is text in this PR that has not been internationalized, implementing this is not required; add a @TODO comment and create a github issue about it.
- [x] There are no linter errors
- [x] Has Pint been run?
- [ ] Have the required updates to the .env.example been made?

# Code Review, Blitz Phase
- [ ] QA not required, but go ahead and do if the situation requires it
- [ ] PR should be squash merged
- [ ] Code reviewer can go ahead and merge a PR after approving the code review
- [ ] Don't forget to delete your feature branch upon merge. Ignore this step as required.

#  Pre-Approval, Post Blitz Phase
- [ ] @TODO add everything above
- [ ] New features have responsive design (i.e., look aesthetically pleasing both full screen and with small or mobile screens)
- [ ] All new text is preferably internationalized

#  Post-Approval, Post Blitz Phase
- [ ] If this PR makes any changes that would require additional configuration of any Symbiota portals outside of the files tracked in this repository, make sure that those changes are detailed in [this document](https://docs.google.com/document/d/1T7xbXEf2bjjm-PMrlXpUBa69aTMAIROPXVqJqa2ow_I/edit?usp=sharing)
- [ ] TODO discuss: increment the Symbiota version number in the symbase.php file and commit to the `hotfix` branch